### PR TITLE
Don't cache enabled_fields

### DIFF
--- a/lib/rails_core_extensions/active_record_extensions.rb
+++ b/lib/rails_core_extensions/active_record_extensions.rb
@@ -71,7 +71,7 @@ module ActiveRecordExtensions
     def optional_fields(*possible_fields)
       class_eval <<-EVAL
         def self.enabled_fields
-          @@enabled_fields ||= Array.wrap(ActiveSetting::Setting.send("#{self.to_s.underscore}_optional_fields")).map { |f| f.to_s.to_sym }
+          @@enabled_fields = Array.wrap(ActiveSetting::Setting.send("#{self.to_s.underscore}_optional_fields")).map { |f| f.to_s.to_sym }
         end
 
         def self.enabled_fields=(fields)


### PR DESCRIPTION
Because at load time tenant is null so optional fields setting is incorrect