### PR TITLE
Extract transfer_records to class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 * Add rails 5 support
 * Refactor clone_excluding to enable rails 5 support
+* Extract transfer_records to class

--- a/lib/rails_core_extensions.rb
+++ b/lib/rails_core_extensions.rb
@@ -6,6 +6,7 @@ module RailsCoreExtensions
   require 'rails_core_extensions/breadcrumb'
   require 'rails_core_extensions/position_initializer'
   require 'rails_core_extensions/time_with_zone'
+  require 'rails_core_extensions/transfer_records'
   require 'rails_core_extensions/active_support_concern'
   require 'rails_core_extensions/concurrency'
 

--- a/lib/rails_core_extensions/active_record_extensions.rb
+++ b/lib/rails_core_extensions/active_record_extensions.rb
@@ -190,17 +190,5 @@ module ActiveRecordExtensions
     def t(key, options = {})
       self.class.translate(key, options)
     end
-
-    def transfer_records(klass, objects, options = {})
-      record_ids = objects.flat_map { |o|
-        o.send(klass.name.underscore + '_ids')
-      }
-      unless record_ids.empty?
-        options[:foreign_key] ||= self.class.name.underscore + '_id'
-        update_options = options.except(:foreign_key)
-        update_options[options[:foreign_key]] = id
-        klass.where(id: record_ids).update_all(update_options)
-      end
-    end
   end
 end

--- a/lib/rails_core_extensions/transfer_records.rb
+++ b/lib/rails_core_extensions/transfer_records.rb
@@ -1,0 +1,21 @@
+module RailsCoreExtensions
+  class TransferRecords
+    def initialize(parent, klass, options = {})
+      @parent = parent
+      @klass = klass
+      @options = options
+    end
+
+    def transfer_from(objects)
+      record_ids = objects.flat_map { |o|
+        o.send(@klass.name.underscore + '_ids')
+      }
+      unless record_ids.empty?
+        @options[:foreign_key] ||= @parent.class.name.underscore + '_id'
+        update_options = @options.except(:foreign_key)
+        update_options[@options[:foreign_key]] = @parent.id
+        @klass.where(id: record_ids).update_all(update_options)
+      end
+    end
+  end
+end

--- a/spec/active_record_extensions_spec.rb
+++ b/spec/active_record_extensions_spec.rb
@@ -103,40 +103,6 @@ describe RailsCoreExtensions::ActionControllerSortable do
 end
 
 describe ActiveRecordExtensions do
-  class Parent < ActiveRecord::Base
-    has_many :children, dependent: :destroy
-    def transfer_children_from(old_parent)
-      transfer_records(Child, [old_parent])
-    end
-  end
-  class Child < ActiveRecord::Base
-    belongs_to :parent
-  end
-
-  let(:old) { Parent.create! }
-  let(:new) { Parent.create! }
-
-  before do
-    connect_to_sqlite
-    new.children.create!
-    old.children.create!
-  end
-
-  after do
-    old.destroy
-    new.destroy
-  end
-
-  it 'should transfer records' do
-    expect(new.children.size).to eq 1
-    expect(old.children.size).to eq 1
-    new.transfer_children_from(old)
-    expect(new.reload.children.size).to eq 2
-    expect(old.reload.children.size).to eq 0
-  end
-end
-
-describe ActiveRecordExtensions do
   let(:model_class) {
     Class.new(ActiveRecord::Base) do
       cache_all_attributes :by => 'name'

--- a/spec/transfer_records_spec.rb
+++ b/spec/transfer_records_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe RailsCoreExtensions::TransferRecords do
+  class Parent < ActiveRecord::Base
+    has_many :children, dependent: :destroy
+    def transfer_children_from(old_parent)
+      RailsCoreExtensions::TransferRecords.new(self, Child).transfer_from([old_parent])
+    end
+  end
+  class Child < ActiveRecord::Base
+    belongs_to :parent
+  end
+
+  let(:old) { Parent.create! }
+  let(:new) { Parent.create! }
+
+  before do
+    connect_to_sqlite
+    new.children.create!
+    old.children.create!
+  end
+
+  after do
+    old.destroy
+    new.destroy
+  end
+
+  it 'should transfer records' do
+    expect(new.children.size).to eq 1
+    expect(old.children.size).to eq 1
+    new.transfer_children_from(old)
+    expect(new.reload.children.size).to eq 2
+    expect(old.reload.children.size).to eq 0
+  end
+end
+


### PR DESCRIPTION
 * Ensures not globally available, only where needed
   (One place in QT)
 * Ensures not private, so can be called outside model class