### PR TITLE
Replace alias_method_chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ pkg
 coverage
 Gemfile.lock
 tmp
+vendor
+.bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Use coverage kit to enforce maximum coverage
+* [RU-133] Replace alias_method_chain with alias_method
 
 ## 0.2.0
 

--- a/lib/rails_core_extensions/concurrency.rb
+++ b/lib/rails_core_extensions/concurrency.rb
@@ -46,8 +46,8 @@ module Concurrency
           end
           return_value
         end
-
-        alias_method_chain :#{method}, :concurrency_lock
+        alias_method :#{method}_without_concurrency_lock, :#{method}
+        alias_method :#{method}, :#{method}_with_concurrency_lock
       DEFINITION
       
       if method_type(method, options[:type]) == 'class'


### PR DESCRIPTION
Why alias_method_chain is deprecated and removed entirely in rails 5.1