### PR TITLE
Rot 31 force cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Use coverage kit to enforce maximum coverage
+* [ROT-73] Always cache cacheable attributes
 
 ## 0.2.0
 

--- a/lib/rails_core_extensions/active_record_cache_all_attributes.rb
+++ b/lib/rails_core_extensions/active_record_cache_all_attributes.rb
@@ -5,7 +5,7 @@ module ActiveRecordCacheAllAttributes
 
   module InstanceMethods
     def clear_attribute_cache
-      self.class.cache.delete("#{self.class.name}.attribute_cache") if self.class.should_cache?
+      self.class.cache.delete("#{self.class.name}.attribute_cache")
     end
   end
 
@@ -16,11 +16,7 @@ module ActiveRecordCacheAllAttributes
 
     def attribute_cache
       cache_key = "#{self.name}.attribute_cache"
-      if self.should_cache?
-        cache.read(cache_key) || self.generate_cache(cache_key)
-      else
-        self.generate_attributes_hash
-      end
+      cache.read(cache_key) || self.generate_cache(cache_key)
     end
 
     def generate_attributes_hash
@@ -34,10 +30,6 @@ module ActiveRecordCacheAllAttributes
         cache.write(cache_key, cache_value)
       end
       cache_value
-    end
-
-    def should_cache?
-      Rails.configuration.action_controller.perform_caching
     end
   end
 end


### PR DESCRIPTION
Where we mostly use this in quicktravel is for caching setting values, however if caching is turned off (say development mode) than performance becomes un-acceptable as for each setting lookup it needs to perform an entire reload of the yml file.  

Caching the attributes in quicktravel is not possible as we need to ensure that it is cached on a per-tenant basis, which happens when the multi-tenancy gem updates for redis. 

Potentially we could add a new configuration hook, but frankly I cant see a situation where I would want to turn the caching off.
