### PR TITLE
Fix include blank for boolean select tag

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -35,7 +35,6 @@ Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
-  MaxLineLength: 100
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
   Enabled: false
@@ -118,20 +117,12 @@ Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in argument lists.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
-    - comma
-    - consistent_comma
-    - no_comma
   Enabled: true
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description: Checks for trailing comma in array and hash literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
-    - comma
-    - consistent_comma
-    - no_comma
-Enabled: true
+  Enabled: true
 Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
     conditions.
@@ -234,9 +225,6 @@ Lint/EachWithObjectArgument:
 Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
-  Enabled: false
-Lint/LiteralInCondition:
-  Description: Checks of literals used in conditions.
   Enabled: false
 Lint/LiteralInInterpolation:
   Description: Checks for literals used in interpolation.

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -97,22 +97,6 @@ Style/SingleLineMethods:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-single-line-methods
   Enabled: false
   AllowIfMethodIsEmpty: true
-Style/StringLiterals:
-  Description: Checks if uses of quotes match the configured preference.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
-  Enabled: true
-  EnforcedStyle: single_quotes
-  SupportedStyles:
-  - single_quotes
-  - double_quotes
-Style/StringLiteralsInInterpolation:
-  Description: Checks if uses of quotes inside expressions in interpolated strings
-    match the configured preference.
-  Enabled: true
-  EnforcedStyle: single_quotes
-  SupportedStyles:
-  - single_quotes
-  - double_quotes
 Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in argument lists.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
@@ -228,4 +212,6 @@ Lint/HandleExceptions:
   Enabled: false
 Lint/LiteralInInterpolation:
   Description: Checks for literals used in interpolation.
+  Enabled: false
+Style/FrozenStringLiteralComment:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ notifications:
     secure: A0XTB5fVkDI9PSeyA4kMIckB4EPdoBlCIae+zatkcqlUJcqTc9wMFSrlnjzA4x+ramqGlwprPXUtEGVVEJwBcoaUjSOnNqZjeRAE1HuZ3D91/UaXZArp+skTGkO/qqek6pSYsAwODN5Q/Fr0qpV6cRzUuQ9nvGA/8sg/Ano2Cno=
 sudo: false
 cache: bundler
+# Due to this issue, stil not resolved: travis-ci/travis-ci#8969
+before_install:
+  - gem update --system
+  - gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+* Support include_blank properly (was broken)
+
 ## 0.4.0 (Removes Rails3 Support)
 
 * [TT-3778] Store the cacheable attributes in memory for the duration of the request

--- a/lib/rails_core_extensions/action_view_extensions.rb
+++ b/lib/rails_core_extensions/action_view_extensions.rb
@@ -53,8 +53,7 @@ module RailsCoreExtensions
       options = args.extract_options!
       options ||= {}
       opts = [['Yes', '1'], ['No', '0']]
-      opts = [blank_option] + opts if options[:include_blank]
-      select_tag name, options_for_select(opts, options[:selected])
+      select_tag name, options_for_select(opts, options[:selected]), options.except(:selected)
     end
   end
 end

--- a/lib/rails_core_extensions/action_view_extensions.rb
+++ b/lib/rails_core_extensions/action_view_extensions.rb
@@ -52,8 +52,9 @@ module RailsCoreExtensions
     def boolean_select_tag(name, *args)
       options = args.extract_options!
       options ||= {}
-      opts = [['Yes', '1'], ['No', '0']]
-      select_tag name, options_for_select(opts, options[:selected]), options.except(:selected)
+      yes_no_opts = [%w[Yes 1], %w[No 0]]
+      option_tags = options_for_select(yes_no_opts, options[:selected])
+      select_tag name, option_tags, options.except(:selected)
     end
   end
 end

--- a/rails_core_extensions.gemspec
+++ b/rails_core_extensions.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coverage-kit'
   spec.add_development_dependency 'simplecov-rcov'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'travis'
 

--- a/spec/action_view_extensions_spec.rb
+++ b/spec/action_view_extensions_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_core_extensions/action_view_extensions'
+require "rails_core_extensions/action_view_extensions"
 
-require 'action_view'
+require "action_view"
 
 describe RailsCoreExtensions::ActionViewExtensions do
   before do
@@ -11,23 +11,29 @@ describe RailsCoreExtensions::ActionViewExtensions do
     end
   end
 
-  after { Object.send(:remove_const, 'TestModel1') }
+  after { Object.send(:remove_const, "TestModel1") }
 
   let(:helper) { TestModel1.new }
 
-  context '#boolean_select_tag' do
-    let(:yes_no) { [["Yes", "1"], ["No", "0"]] }
-    subject { helper.boolean_select_tag('name', args) }
+  context "#boolean_select_tag" do
+    let(:yes_no) { [%w[Yes 1], %w[No 0]] }
+    subject { helper.boolean_select_tag("name", args) }
 
-    context 'when elements selected' do
+    context "when elements selected" do
       let(:args) { { selected: 0 } }
-      let(:options) { helper.options_for_select(yes_no, selected: '0') }
+      let(:options) { helper.options_for_select(yes_no, selected: "0") }
 
-      it { is_expected.to eq helper.select_tag('name', options) }
+      it { is_expected.to eq helper.select_tag("name", options) }
 
-      context 'and other options passed' do
-        let(:args) { { selected: '0', include_blank: 'All' } }
-        it { is_expected.to eq helper.select_tag('name', options, include_blank: 'All') }
+      context "and other options passed" do
+        let(:args) { { selected: "0", include_blank: "All" } }
+        it {
+          is_expected.to eq helper.select_tag(
+            "name",
+            options,
+            include_blank: "All",
+          )
+        }
       end
     end
   end

--- a/spec/action_view_extensions_spec.rb
+++ b/spec/action_view_extensions_spec.rb
@@ -24,6 +24,11 @@ describe RailsCoreExtensions::ActionViewExtensions do
       let(:options) { helper.options_for_select(yes_no, selected: '0') }
 
       it { is_expected.to eq helper.select_tag('name', options) }
+
+      context 'and other options passed' do
+        let(:args) { { selected: '0', include_blank: 'All' } }
+        it { is_expected.to eq helper.select_tag('name', options, include_blank: 'All') }
+      end
     end
   end
 end

--- a/spec/action_view_extensions_spec.rb
+++ b/spec/action_view_extensions_spec.rb
@@ -13,13 +13,17 @@ describe RailsCoreExtensions::ActionViewExtensions do
 
   after { Object.send(:remove_const, 'TestModel1') }
 
-  subject { TestModel1.new }
+  let(:helper) { TestModel1.new }
 
   context '#boolean_select_tag' do
-    it 'should generate and have selected element selected' do
-      expect(subject.boolean_select_tag('name', selected: '0')).to eq(
-        subject.select_tag('name', subject.options_for_select([['Yes', '1'], ['No', '0']], selected: '0'))
-      )
+    let(:yes_no) { [["Yes", "1"], ["No", "0"]] }
+    subject { helper.boolean_select_tag('name', args) }
+
+    context 'when elements selected' do
+      let(:args) { { selected: 0 } }
+      let(:options) { helper.options_for_select(yes_no, selected: '0') }
+
+      it { is_expected.to eq helper.select_tag('name', options) }
     end
   end
 end


### PR DESCRIPTION
**WHY** - When this method was moved to rails_core_extensions blank_option wasn't moved with it, but in reality it shouldn't be used anyway, we merely need to use include_blank directly with the select_tag as it was designed to be used

This adds tests and fixes the issue.