### PR TITLE
Tt 5542 remove rails4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.4
   - 2.5
-  - 2.6
 script: "bundle exec rake spec"
 gemfile:
   - gemfiles/rails5.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.4
   - 2.5
+  - 2.6
 script: "bundle exec rake spec"
 gemfile:
   - gemfiles/rails5.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,9 @@
 language: ruby
 rvm:
-  - 2.3
   - 2.4
   - 2.5
 script: "bundle exec rake spec"
 gemfile:
-  - gemfiles/rails4.gemfile
   - gemfiles/rails5.gemfile
-notifications:
-  email:
-    - support@travellink.com.au
-  flowdock:
-    secure: A0XTB5fVkDI9PSeyA4kMIckB4EPdoBlCIae+zatkcqlUJcqTc9wMFSrlnjzA4x+ramqGlwprPXUtEGVVEJwBcoaUjSOnNqZjeRAE1HuZ3D91/UaXZArp+skTGkO/qqek6pSYsAwODN5Q/Fr0qpV6cRzUuQ9nvGA/8sg/Ano2Cno=
 sudo: false
 cache: bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleaed
+
+* [TT-5542] Remove Rails 4 support
+
 ## 0.4.0 (Removes Rails3 Support)
 
 * [TT-3778] Store the cacheable attributes in memory for the duration of the request

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -1,6 +1,0 @@
-source :rubygems
-gemspec :path => '../'
-
-group :development, :test do
-  gem 'activerecord', '~> 4.0'
-end

--- a/rails_core_extensions.gemspec
+++ b/rails_core_extensions.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', ['>= 4.0.0']
-  spec.add_dependency 'actionpack', ['>= 4.0.0']
+  spec.add_dependency 'activerecord', ['>= 5.0.0']
+  spec.add_dependency 'actionpack', ['>= 5.0.0']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'activerecord-nulldb-adapter'


### PR DESCRIPTION
WHY

Remove legacy rails versions from the build matrix