### PR TITLE
Tt 5384 remove validate presence of parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* [TT-5384] Remove validates_presence_of_parent method (Use rails optional flag instead)
+
 ## 0.7.1
 
 * [TT-5745] Fix passing of symbol to liquid template parse

--- a/lib/rails_core_extensions/active_record_extensions.rb
+++ b/lib/rails_core_extensions/active_record_extensions.rb
@@ -109,17 +109,6 @@ module ActiveRecordExtensions
       end
     end
 
-    # Validates presence of -- but works on parent within accepts_nested_attributes
-    #
-    def validates_presence_of_parent(foreign_key)
-      after_save do |record|
-        unless record.send(foreign_key)
-          record.errors.add_on_blank(foreign_key)
-          raise ActiveRecord::ActiveRecordError, record.errors.full_messages.to_sentence
-        end
-      end
-    end
-
     # Run a block, being respectful of connection pools
     #
     # Useful for when you're not in the standard rails request process,

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -1,4 +1,4 @@
 require 'simplecov-rcov'
 require 'coveralls'
 require 'coverage/kit'
-Coverage::Kit.setup(minimum_coverage: 81.3)
+Coverage::Kit.setup(minimum_coverage: 82.1)


### PR DESCRIPTION
**WHY**

This can be replaced in rails using the optional: false flag on the association