### PR TITLE
Fix broken rake command during gem publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
-      - run: bundle exec rake
 
       - name: Publish to RubyGems
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.1 Unreleased
+
+* [TT-8608] Fix broken rake command in the gem publish stage
+
 ## 0.11.0
 
 * [TT-8608] Switch from travis to gihthub actions


### PR DESCRIPTION
### WHY

Left in a rake build command which did not work and is not required anyway