### PR TITLE
Plat 384 fix broken extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [PLAT-384] Fix the liquid extension
+
 ## 0.13.0
 
 - [PLAT-378] Improve bundler startup time; Drop Concurrency

--- a/lib/rails_core_extensions/active_record_liquid_extensions.rb
+++ b/lib/rails_core_extensions/active_record_liquid_extensions.rb
@@ -1,30 +1,30 @@
 module RailsCoreExtensions
   module ActiveRecordLiquidExtensions
     extend ActiveSupport::Concern
-  end
 
-  module ClassMethods
-    def validates_liquid(field)
-      field = field.to_sym
-      before_validation do |record|
-        begin
-          Liquid::Template.parse(record.send(field), error_mode: :strict)
-        rescue Liquid::SyntaxError => e
-          record.errors.add(field, "Liquid Syntax Error: #{e}")
+    module ClassMethods
+      def validates_liquid(field)
+        field = field.to_sym
+        before_validation do |record|
+          begin
+            Liquid::Template.parse(record.send(field), error_mode: :strict)
+          rescue Liquid::SyntaxError => e
+            record.errors.add(field, "Liquid Syntax Error: #{e}")
+          end
         end
       end
-    end
 
-    def liquid_field(field)
-      class_eval <<-CODE
-        def parsed_#{field}
-          Liquid::Template.parse(#{field})
-        end
+      def liquid_field(field)
+        class_eval <<-CODE
+          def parsed_#{field}
+            Liquid::Template.parse(#{field})
+          end
 
-        def render_#{field}(*args)
-          parsed_#{field}.render!(*args)
-        end
-      CODE
+          def render_#{field}(*args)
+            parsed_#{field}.render!(*args)
+          end
+        CODE
+      end
     end
   end
 end


### PR DESCRIPTION
### WHY

The real active support concern works differently to what our "custom" implementation did so this caused the liquid extensions to not work properly when used in QT