### PR TITLE
Fix lazy loading of action_view extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [PLAT-390] Fix broken `action_view` extensions
+
 ## 0.13.1
 
 - [PLAT-384] Fix the liquid extension

--- a/lib/rails_core_extensions.rb
+++ b/lib/rails_core_extensions.rb
@@ -20,7 +20,7 @@ module RailsCoreExtensions
     require 'rails_core_extensions/action_view_extensions'
     require 'rails_core_extensions/action_view_has_many_extensions'
 
-    ActiveSupport.on_load(:active_view) do
+    ActiveSupport.on_load(:action_view) do
       ActionView::Base.send(:include, RailsCoreExtensions::ActionViewExtensions)
     end
   end


### PR DESCRIPTION
### WHY

Should be `action_view` and NOT `active_view`