### PR TITLE
Plat 1135 remove enum int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [PLAT-1135] Remove `enum_int` as we have now fully migrated to rails native `enum`
+
 ## 0.13.2
 
 - [PLAT-390] Fix broken `action_view` extensions

--- a/lib/rails_core_extensions/active_record_extensions.rb
+++ b/lib/rails_core_extensions/active_record_extensions.rb
@@ -9,28 +9,6 @@ module ActiveRecordExtensions
       establish_connection("#{key}_#{Rails.env}")
     end
 
-    def enum_int(field, values, options = {})
-      const_set("#{field.to_s.upcase}_OPTIONS", values)
-
-      select_options = values.map.with_index{|v, i| [v.to_s.humanize, i]}
-      const_set("#{field.to_s.upcase}_SELECT_OPTIONS", select_options)
-
-      values.each.with_index do |value, i|
-        const_set("#{field.to_s.upcase}_#{value.to_s.upcase}", i)
-        method_name = options[:short_name] ? "#{value}?" : "#{field}_#{value}?"
-        class_eval <<-ENUM
-          def #{method_name}
-            #{field} == #{i}
-          end
-        ENUM
-      end
-      class_eval <<-ENUM
-        def #{field}_name
-          #{field.to_s.upcase}_OPTIONS[#{field}]
-        end
-      ENUM
-    end
-
     def optional_fields(*possible_fields)
       @optional_fields_loader = possible_fields.pop if possible_fields.last.is_a?(Proc)
 

--- a/spec/active_record_extensions_spec.rb
+++ b/spec/active_record_extensions_spec.rb
@@ -22,52 +22,6 @@ describe "optional_fields" do
   end
 end
 
-describe 'enum_int' do
-  let(:model_class) {
-    Class.new(ActiveRecord::Base) do
-      enum_int :category_id, %w(one two thr)
-    end
-  }
-  before do
-    connect_to_sqlite
-    stub_const 'Model', model_class
-  end
-  let(:one) { Model.new(category_id: 'one') }
-
-  it 'should define constants' do
-    expect(Model::CATEGORY_ID_OPTIONS).to eq %w(one two thr)
-    expect(Model::CATEGORY_ID_ONE).to eq 0
-    expect(Model::CATEGORY_ID_TWO).to eq 1
-    expect(Model::CATEGORY_ID_THR).to eq 2
-  end
-
-  it 'should define methods' do
-    expect(one.category_id_one?).to be true
-    expect(one.category_id_two?).to be false
-    expect(one.category_id_thr?).to be false
-  end
-
-  it 'should define select options' do
-    expect(Model::CATEGORY_ID_SELECT_OPTIONS).to eq([
-      ['One', 0], ['Two', 1], ['Thr', 2]
-    ])
-  end
-
-  context 'when short name' do
-    let(:model_class) {
-      Class.new(ActiveRecord::Base) do
-        enum_int :category_id, %w(one two thr), short_name: true
-      end
-    }
-
-    it 'should define methods' do
-      expect(one.one?).to be true
-      expect(one.two?).to be false
-      expect(one.thr?).to be false
-    end
-  end
-end
-
 describe RailsCoreExtensions::ActionControllerSortable do
   class NormalController < ActionController::Base
   end

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -1,3 +1,3 @@
 require 'coverage/kit'
 
-Coverage::Kit.setup(minimum_coverage: 84.1)
+Coverage::Kit.setup(minimum_coverage: 83.5)


### PR DESCRIPTION
### WHY

We have fully migrated to rails native enum so we no longer need this method